### PR TITLE
geometry.pl

### DIFF
--- a/clas12/ec/geometry.pl
+++ b/clas12/ec/geometry.pl
@@ -382,7 +382,20 @@ sub build_scintlayers
 	
 	$description ="Forward Calorimeter scintillator layer ${i}";
     $pos = "$xscint*mm $yscint*mm $zscint*mm";
+# a scintillator layer first. set the G4Trap parameters.
 
+    my $pDx1   = 0.001;  # should be zero, but that makes gemc crash.
+    my $pDx2   = &spDx2(1);
+    my $pDz    = $dscint/2.0;  #<-------------------------------------
+    my $pTheta = 0;
+    my $pPhi   = $pTheta;
+    my $pDy1   = &spDy(1);
+    my $pDy2   = $pDy1;
+    my $pDx3   = $pDx1;
+    my $pDx4   = $pDx2;
+    my $pAlp1  = $pTheta;
+    my $pAlp2  = $pTheta;
+    
     my %detector = init_det();
     $detector{"name"}        = $subname;
     $detector{"mother"}      = "ec_s".$sector;
@@ -400,19 +413,7 @@ sub build_scintlayers
     print_det(\%configuration, \%detector);
 
 	# loop over layers and generates Geant4 parameters for each scint and lead layer.
-# a scintillator layer first. set the G4Trap parameters.
-#
-    my $pDx1   = 0.001;  # should be zero, but that makes gemc crash.
-    my $pDx2   = &spDx2(1);
-    my $pDz    = $dscint/2.0;  #<-------------------------------------
-    my $pTheta = 0;
-    my $pPhi   = $pTheta;
-    my $pDy1   = &spDy(1);
-    my $pDy2   = $pDy1;
-    my $pDx3   = $pDx1;
-    my $pDx4   = $pDx2;
-    my $pAlp1  = $pTheta;
-    my $pAlp2  = $pTheta;
+
 
     for ($i = 2; $i <= $nlayers; $i++)
 	{

--- a/clas12/ec/geometry.pl
+++ b/clas12/ec/geometry.pl
@@ -588,8 +588,8 @@ sub ECstack($)
     my $layer = $_[0];
 
     my $stack = 3;
-    if ($i <= 15) {$stack = 1;}
-    if ($i >  15) {$stack = 2;}
+    if ($layer <= 15) {$stack = 1;}
+    if ($layer >  15) {$stack = 2;}
     if ($stack == 3) {print "**** WARNING: No Stack assignment made. ****\n";
     }
 

--- a/clas12/ec/geometry.pl
+++ b/clas12/ec/geometry.pl
@@ -365,9 +365,8 @@ sub define_scintlayers
 
 sub build_scintlayers
 {
-    my $i = 1;
     my $sector = shift;
-
+    my $i      = 1;
     my $xscint = &sxcenter($i);
     my $yscint = &sycenter($i);
     my $zscint = &szcenter($i);
@@ -401,6 +400,19 @@ sub build_scintlayers
     print_det(\%configuration, \%detector);
 
 	# loop over layers and generates Geant4 parameters for each scint and lead layer.
+# a scintillator layer first. set the G4Trap parameters.
+#
+    my $pDx1   = 0.001;  # should be zero, but that makes gemc crash.
+    my $pDx2   = &spDx2(1);
+    my $pDz    = $dscint/2.0;  #<-------------------------------------
+    my $pTheta = 0;
+    my $pPhi   = $pTheta;
+    my $pDy1   = &spDy(1);
+    my $pDy2   = $pDy1;
+    my $pDx3   = $pDx1;
+    my $pDx4   = $pDx2;
+    my $pAlp1  = $pTheta;
+    my $pAlp2  = $pTheta;
 
     for ($i = 2; $i <= $nlayers; $i++)
 	{


### PR DESCRIPTION
Both index $i and G4Trap parameters for scintillator 1 have to be initialized in build_scintlayers.  I copied lines 263-275 into lines 385-397 to accomplish this.  Below shows scintillator 1 now has correct position and size for all sectors. 

Addendum: Final bug was found in sub ECstack() where index $i was used instead of $layer, causing stack 1 to be assigned to all scintillators instead of for only layers 1-15.  Fixed.  Thanks to Mauri for finding this one for me.  Now the average energy in the U layers is the same as V and W (see plot at bottom).

- Cole Smith

![geometry pl fix](https://cloud.githubusercontent.com/assets/10797791/9027466/d9eda5d6-3923-11e5-8c9a-50e28b6573b2.png)
![after-ecstack-bug-fix](https://cloud.githubusercontent.com/assets/10797791/9048550/fb39a872-3a07-11e5-8e10-ae6f4b9e4469.png)
