### PR TITLE
 fixing pb layer in ftof

### DIFF
--- a/clas12/ftof/utils.pl
+++ b/clas12/ftof/utils.pl
@@ -307,7 +307,7 @@ sub pb_pos
 {
     # shift the lead forward wrt mother center
     # by a distance half the thickness of the counters
-    my $ypos = -1*(0.001 + fstr($panel1b_w/2.0 + $mothergap));
+    my $ypos = (0.001 + fstr($panel1b_w/2.0 + $mothergap));
     return "0*inches $ypos*inches 0*inches";
 }
 


### PR DESCRIPTION
Changes the side of 1b that the lead is rendered on.   Now Pb layer should build in middle of 1a and 1b.