### PR TITLE
3 var cone shielding

### DIFF
--- a/clas12/ddvcs/beamSupport.pl
+++ b/clas12/ddvcs/beamSupport.pl
@@ -21,6 +21,11 @@ our $Smax ;
 
 our $CrminU;
 
+our $CexitAngle;
+
+our $Addoradius;
+our $AddsupportLength;
+
 
 sub buildBeamPipe
 {
@@ -39,9 +44,9 @@ sub buildBeamPipe
 	
 	my $pipeORS = $pipeOR + $microgap;
 	
-   my @mucal_zpos    = ( $CZpos              , $CZpos +  $Clength + 2*$microgap, $CZpos +  $Clength + 2*$microgap, $CZpos +  $Clength + $supportLength);
+   my @mucal_zpos    = ( $CZpos              , $CZpos +  $Clength + 2*$microgap, $CZpos +  $Clength + 2*$microgap, $CZpos +  $Clength + $supportLength + $AddsupportLength);
    my @mucal_iradius = ( $pipeORS            , $pipeORS                        , $pipeORS                        ,  $pipeORS                           );
-   my @mucal_oradius = ( $CrminU - $microgap , $CrminD - $microgap             , $CrmaxD                         ,  $Smax                            );
+   my @mucal_oradius = ( $CrminU - $microgap , $CrminD - $microgap             , $CrmaxD + $Addoradius                       ,  $Smax + $Addoradius + $AddsupportLength*tan($CexitAngle)                            );
 
    
    my $nplanes = 4;
@@ -64,4 +69,3 @@ sub buildBeamPipe
    print_det(\%configuration, \%detector);
 
 }
-

--- a/clas12/ddvcs/ddvcs.pl
+++ b/clas12/ddvcs/ddvcs.pl
@@ -59,8 +59,17 @@ our $pipeL  = 1000;
 # shield
 our $TSThick  = 300;
 our $TSLength = 1500;
-our $TSrmax = $Smax + $TSThick*tan($CexitAngle) + 10;
+our $TSrmax = $Smax + $TSThick*tan($CexitAngle);
 
+
+# Thickness of the pipe shielding
+our $ShieldThick = $pipeOR + $microgap + 150;
+
+# Additional length to outer radius
+our $Addoradius = 250;
+
+# Additional length/thickness to the support
+our $AddsupportLength = 50;
 
 
 # Loading configuration file from argument
@@ -75,7 +84,7 @@ require "./muCal.pl";
 require "./beamSupport.pl";
 
 # all the scripts must be run for every configuration
-my @allConfs = ("original");
+my @allConfs = ("30_cm_TST", "50_cm_TST", "80_cm_TST");
 
 foreach my $conf ( @allConfs )
 {

--- a/clas12/ddvcs/ddvcsCone.pl
+++ b/clas12/ddvcs/ddvcsCone.pl
@@ -20,17 +20,28 @@ our $TSrmax;
 our $TSThick;
 our $TSLength;
 
+our $CexitAngle;
+
+our $ShieldThick;
+
+our $Addoradius;
+our $AddsupportLength;
+
 
 sub buildBeamShield
 {
-	
-   my $startz = $CZpos +  $Clength + $supportLength + $microgap;
+	my $AddTSThick;
+	if($configuration{"variation"} eq "30_cm_TST") {$AddTSThick = 0;}
+	if($configuration{"variation"} eq "50_cm_TST") {$AddTSThick = 200;}
+	if($configuration{"variation"} eq "80_cm_TST") {$AddTSThick = 500;}
+
+   my $startz = $CZpos +  $Clength + $supportLength + $AddsupportLength + $microgap;
 	
    my $pipeORS = $pipeOR + $microgap;
 
-	my @mucal_zpos    = ( $startz , $startz+ $TSThick  , $startz + $TSThick , $startz + $TSLength);
+	my @mucal_zpos    = ( $startz , $startz+ $TSThick + $AddTSThick  , $startz + $TSThick + $AddTSThick , $startz + $TSLength - $AddsupportLength);
    my @mucal_iradius = ( $pipeORS, $pipeORS           , $pipeORS           ,  $pipeORS          );
-   my @mucal_oradius = ( $Smax   , $TSrmax            , $CrminU            ,  $CrminU           );
+   my @mucal_oradius = ( $Smax + $Addoradius + $AddsupportLength*tan($CexitAngle)   , $TSrmax + $Addoradius + $AddsupportLength*tan($CexitAngle) + $AddTSThick*tan($CexitAngle)           , $ShieldThick            ,    $ShieldThick       );
 
    
    my $nplanes = 4;
@@ -53,4 +64,3 @@ sub buildBeamShield
    print_det(\%configuration, \%detector);
 
 }
-


### PR DESCRIPTION
Code editing was done to create three configurations for the cone shielding with thickness 30 cm, 50 cm, and 80 cm. The Al support has its thickness increased by 5 cm and both the support and the shielding cone radii were increased by 25 cm. The protruding tube from the shielding cone is 15 cm.