### PR TITLE
Update geometry_java.pl

### DIFF
--- a/clas12/rich_sector4/geometry_java.pl
+++ b/clas12/rich_sector4/geometry_java.pl
@@ -100,7 +100,7 @@ sub build_Elements
     my $Max_Layer201=16;
     my $Max_Layer202=22;
     my $Max_Layer203=32;
-    my $Max_Layer204=32;
+    my $Max_Layer204=31;
     my $Max_Layer301=7;
     my $Max_Layer302=10;
     


### PR DESCRIPTION
Layer 204 component 32 removed. Now max component for layer 204 is 31. The changes has been implemented since CoatJava and reconstruction don't use that component that is in a non active area of the detector.