### PR TITLE
Fixed the missing material of liquid Helium for the lHe target variation

### DIFF
--- a/clas12/targets/geometry.pl
+++ b/clas12/targets/geometry.pl
@@ -840,7 +840,7 @@ sub build_targets
 			$detector{"material"}    = "LD2";
 		}
 		if($thisVariation eq "lHe") {
-			$detector{"material"}    = "lHe";
+			$detector{"material"}    = "lHeTarget";
 		}
 
 		$detector{"style"}       = 1;

--- a/clas12/targets/materials.pl
+++ b/clas12/targets/materials.pl
@@ -633,4 +633,16 @@ sub materials
         $mat{"components"}    = "G4_He 1";
         print_mat(\%configuration, \%mat);
     }
+    if($thisVariation eq "lHe")
+    {
+	# lHe target
+	%mat = init_mat();
+	$mat{"name"}          = "lHeTarget";
+	$mat{"description"}   = "liquid He target";
+	$mat{"density"}       = "0.125";  # 0.125 g/cm3 <—————————————
+	$mat{"ncomponents"}   = "1";
+	$mat{"components"}    = "G4_He 1";
+	print_mat(\%configuration, \%mat);
+    }
+
 }


### PR DESCRIPTION
The variation for a liquid helium standard liquid 5cm cell existed before but the material was not correctly added. 
The variation name was changed from lh2 to lHe to prevent confusion with lH2 target cell. The material lHeTarget was added for the variation lHe. 