### PR TITLE
Switch RICH mother volume z position back to 0cm (nominal position)

### DIFF
--- a/clas12/rich/geometry.pl
+++ b/clas12/rich/geometry.pl
@@ -94,7 +94,7 @@ sub build_MESH
 		}		
 		$detector{"pos"}         = $positions->{$vname};
 		if($mesh eq "RICH_s4" and ($variation eq "rga_fall2018" or $variation eq "rgc_summer2022")){
-		    $detector{"pos"} = "0*cm 0*cm 5*cm";
+		    $detector{"pos"} = "0*cm 0*cm 0*cm";
 		}
 		#rotate mesh for sector 1 180 deg. around z
 		$detector{"rotation"}    = $rotations->{$vname};


### PR DESCRIPTION
Previously, we had shifted the RICH in the experimental configurations (rg-a, rg-c) 5cm in z as this should be the correct position. However, this seems to result in distorted distributions of the reconstructed Cherenkov angle. With the RICH in the nominal position, we see the expected roughly Gaussian distribution of the reconstructed Cherenkov theta for electrons (both tested throwing individual e- in the RICH sector). 

I'm not exactly sure what the source of this behavior (maybe some misalignment between where the RICH reconstruction thinks the last tracking point is and the actual distance in gemc), but I propose we shift the RICH back to its nominal position. (Opening this as a draft PR for feedback first)

Attached are the referenced plots of reconstructed Cherenkov angle. This was tested with:
1. RICH shifted 5cm in z, with the shift applied the same way in the ccdb/coatjava
2. RICH shifted 5cm in z, ccdb bank for alignment set to 0cm
3. RICH in nominal position, ccdb bank for alignment set to 0cm

![chAngle_rich5cm_cj5cm](https://github.com/gemc/detectors/assets/39525107/225a3f38-10b0-40ef-873f-a94332b4ea09)
![chAng_rich5cm_cj0cm](https://github.com/gemc/detectors/assets/39525107/27660f41-57c8-4d31-9336-7c3dcb871bd3)
![ChAngle_rich0cm_cj0cm](https://github.com/gemc/detectors/assets/39525107/91a73b1e-b398-4b82-a3d9-507ecac5ff5b)
